### PR TITLE
Change base image when gpus enabled to be cuda instead of cudagl

### DIFF
--- a/docker/create.py
+++ b/docker/create.py
@@ -34,7 +34,7 @@ def main():
 
     username = getUsername()
     if gpus:
-        base_image = "nvidia/cudagl:11.4.2-devel"
+        base_image = "nvidia/cuda:12.0.1-devel-ubuntu20.04"
     else:
         base_image = "ubuntu:focal"
     home = Path.home()


### PR DESCRIPTION
We figured that using the `nvidia/cudagl` base image from docker Hub is not adding anything useful to the more common `nvidia/cuda` since OpenGL is being upgraded to 4.5 right away in the Dockerfile.

Hopefully, this reduces the size of the image and container on disk and allows to use a base image that is updated more often and has broader support ( has versions for different ubuntu versions 18.04, 20.04, and 22.04).