### PR TITLE
Add swap rule

### DIFF
--- a/hexgame/board.py
+++ b/hexgame/board.py
@@ -31,7 +31,9 @@ class Board:
         red_conn_comp: UnionFind[tuple[int, int]],
         blue_conn_comp: UnionFind[tuple[int, int]],
         dim_x: int = BOARD_DEFAULT_X_DIM,
-        dim_y: int = BOARD_DEFAULT_Y_DIM
+        dim_y: int = BOARD_DEFAULT_Y_DIM,
+        swap_rule_allowed: bool = True
+
     ) -> None:
         self.dim_x: int = dim_x
         self.dim_y: int = dim_y
@@ -41,6 +43,8 @@ class Board:
                                              int]] = red_conn_comp
         self._blue_conn_comp: UnionFind[tuple[int,
                                               int]] = blue_conn_comp
+        self._swap_rule_allowed: swap_rule_allowed
+        self._number_of_moves_made: int = 0
 
     def __getitem__(self, coord: tuple) -> Cell:
         x, y = coord
@@ -68,7 +72,7 @@ class Board:
         for example, for a 5X5 board:
 
         - - - - -
-         - b - - - 
+         - b - - -
           - - - R -
            - - - b -
             - - R - -
@@ -124,9 +128,11 @@ class Board:
         and recomputes the connected components dictionary
         """
         if self.has_cell((i, j)):
-            if self[i, j].is_empty:
+            if self[i, j].is_empty or (self._swap_rule_allowed and
+                                       self._number_of_moves_made == 1):
                 self[i, j] = Cell(x=i, y=j, color=color)
                 self._update_conn_comp(i, j, color)
+                self._number_of_moves_made += 1
             else:
                 raise ValueError(
                     "Cannot place stone at cell {cell}-"
@@ -249,6 +255,14 @@ class Board:
     @property
     def blue_conn_comp(self) -> UnionFind[tuple[int, int]]:
         return self._blue_conn_comp
+
+    @property
+    def possible_moves(self) -> list[tuple[int, int]]:
+        if self._number_of_moves_made == 1 and self._swap_rule_allowed:
+            return [(x, y) for y, row in enumerate(self._board)
+                    for x, _ in enumerate(row)]
+        else:
+            return empty_positions
 
     @property
     def empty_positions(self) -> list[tuple[int, int]]:

--- a/hexgame/board.py
+++ b/hexgame/board.py
@@ -43,7 +43,7 @@ class Board:
                                              int]] = red_conn_comp
         self._blue_conn_comp: UnionFind[tuple[int,
                                               int]] = blue_conn_comp
-        self._swap_rule_allowed: swap_rule_allowed
+        self._swap_rule_allowed: bool = swap_rule_allowed
         self._number_of_moves_made: int = 0
 
     def __getitem__(self, coord: tuple) -> Cell:
@@ -262,7 +262,7 @@ class Board:
             return [(x, y) for y, row in enumerate(self._board)
                     for x, _ in enumerate(row)]
         else:
-            return empty_positions
+            return self.empty_positions
 
     @property
     def empty_positions(self) -> list[tuple[int, int]]:

--- a/hexgame/player.py
+++ b/hexgame/player.py
@@ -47,9 +47,10 @@ class Player:
         """
         Implements a random policy
         """
-        if (board.empty_positions) != []:
+        available_actions = board.possible_moves
+        if (available_actions) != []:
             next_move: tuple[int, int] = random.choice(
-                board.empty_positions)
+                available_actions)
             i, j = next_move
             new_board = self._place_stone(board, i, j)
             return new_board
@@ -60,7 +61,8 @@ class Player:
         Waits for the keyboard input to get
         a move
         """
-        if (board.empty_positions) != []:
+        available_actions = board.possible_moves
+        if (available_actions) != []:
             valid_coords = False
             while (not valid_coords):
                 print(f"Please insert the coords where to place stone \
@@ -75,7 +77,7 @@ class Player:
                         j = int(inp)
                         try:
                             valid_coords = board.has_cell((i, j)) and (
-                                i, j) in board.empty_positions
+                                i, j) in available_actions
                             new_board = self._place_stone(board, i, j)
                             return new_board
                         except ValueError as e:

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -105,6 +105,17 @@ class TestBoardProperties:
         nbrs = board.find_neighbours(tile)
         assert nbrs == expected
 
+    def test_swap_rule_allowed(self):
+        dim_x = 2
+        dim_y = 2
+        nodes = [(x, y) for y in range(dim_y) for x in range(dim_x)]
+        uf_red = UnionFind(nodes)
+        uf_blue = UnionFind(nodes)
+        board = Board(dim_x=dim_x, dim_y=dim_y,
+                      red_conn_comp=uf_red, blue_conn_comp=uf_blue)
+
+        assert board._swap_rule_allowed
+
     # place_stone
 
     def test_place_stone_on_empty_board(self):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -46,14 +46,14 @@ class TestBoardProperties:
 
     # __str__
     @pytest.mark.parametrize(
-            "board_sizes,expected",
-            [pytest.param(
-                (0, 0), ''
-            ),
-                pytest.param(
-                (3, 4), '- - - \n - - - \n  - - - \n   - - - \n'
-            )]
-            )
+        "board_sizes,expected",
+        [pytest.param(
+            (0, 0), ''
+        ),
+            pytest.param(
+            (3, 4), '- - - \n - - - \n  - - - \n   - - - \n'
+        )]
+    )
     def test__str__empty_board(
             self, board_sizes: tuple[int, int], expected: str):
         fake_uf = UnionFind([(1, 1)])
@@ -119,6 +119,19 @@ class TestBoardProperties:
 
         assert board[1, 2] == Cell(1, 2, Color.Red)
 
+    def test_use_swap_rule(self):
+        dim_x = 3
+        dim_y = 3
+        nodes = [(x, y) for y in range(dim_y) for x in range(dim_x)]
+        uf_red = UnionFind(nodes)
+        uf_blue = UnionFind(nodes)
+        board = Board(dim_x=dim_x, dim_y=dim_y,
+                      red_conn_comp=uf_red, blue_conn_comp=uf_blue)
+        board.place_stone(1, 2, color=Color.Red)
+
+        board.place_stone(1, 2, color=Color.Blue)
+        assert board[1, 2].color == Color.Blue
+
     def test_place_stone_already_filled(self):
         with pytest.raises(ValueError):
             dim_x = 3
@@ -128,6 +141,8 @@ class TestBoardProperties:
             uf_blue = UnionFind(nodes)
             board = Board(dim_x=dim_x, dim_y=dim_y,
                           red_conn_comp=uf_red, blue_conn_comp=uf_blue)
+            board.place_stone(0, 0, color=Color.Blue)
+
             board.place_stone(1, 2, color=Color.Red)
 
             board.place_stone(1, 2, color=Color.Blue)


### PR DESCRIPTION
We are adding the swap rule to the game.

In order to do so we introduced two instance variables to `Board`:
-  _swap_rule_allowed
-  _number_of_moves_made
 

Then we implement a different check in `place_stone` were it checks if it only one move has been made, in that case is possible to place a stone in a non empty square.

Added a wrapper aroud `empty_positions` called `possible_moves` to include the swap case if it is the first turn of the game.


Tested also in a game:
 
![Screenshot from 2023-04-26 18-12-01](https://user-images.githubusercontent.com/14253035/234653367-b7d493e9-6199-44ce-925e-515168967070.png)
