### PR TITLE
Rust impementation - add swap rule

### DIFF
--- a/hexgame-rs/src/game/cell.rs
+++ b/hexgame-rs/src/game/cell.rs
@@ -51,9 +51,9 @@ mod tests {
     }
 
     #[test]
-    fn test_equals(){
+    fn test_equals() {
         let c_1: Cell = Cell::new_from_ownership(0, 1, Ownership::Player1);
-        let mut c_2: Cell = Cell::new(0,1);
+        let mut c_2: Cell = Cell::new(0, 1);
         assert_ne!(c_1, c_2);
         c_2.ownership = Ownership::Player1;
         assert_eq!(c_1, c_2);

--- a/hexgame-rs/src/game/game.rs
+++ b/hexgame-rs/src/game/game.rs
@@ -20,7 +20,7 @@ impl Agent {
 
 impl RandomPlay for Agent {
     fn choose_next_move(&self, board: &Board) -> (usize, usize) {
-        let possible_moves: Vec<(usize, usize)> = board.get_unoccupied_squares();
+        let possible_moves: Vec<(usize, usize)> = board.get_possible_moves();
         if possible_moves.len() == 0 {
             panic!("there are no more possible moves to made on the board, the game should have already ended");
         }

--- a/hexgame-rs/src/game/mod.rs
+++ b/hexgame-rs/src/game/mod.rs
@@ -1,4 +1,3 @@
-pub mod cell;
 pub mod board;
+pub mod cell;
 pub mod game;
-

--- a/hexgame-rs/src/main.rs
+++ b/hexgame-rs/src/main.rs
@@ -1,8 +1,7 @@
 pub mod game;
 use game::game::Game;
 
-
 fn main() {
-    let mut game = Game::new( 3 );
+    let mut game = Game::new(3);
     game.play();
 }


### PR DESCRIPTION
Implementing swap rule in rust adding `turn_number` and `swap_rule_flag` as class variables.

Also changed the way the random policy chooses the action (now through `get_possible_moves` rather than `get_unoccupied_squares`).

Possibly, it is worth it to deprecate `get_unoccupied_squares`.