### PR TITLE
GitHub workflow upload released package pypi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,30 @@
+    name: Upload Python Package
+
+    on:
+      pull_request:
+        types: [closed]
+
+    jobs:
+      deploy:
+        if: github.event.pull_request.merged == true &&
+          contains(github.event.issue.labels.*.name, 'release')
+
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v3
+        - name: Set up Python
+          uses: actions/setup-python@v4
+          with:
+            python-version: '3.x'
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install setuptools wheel twine
+        - name: Build and publish
+          env:
+            TWINE_USERNAME: __token__
+            TWINE_PASSWORD: secrets.PYPI_TOKEN
+          run: |
+            python setup.py sdist bdist_wheel
+            twine upload dist/*


### PR DESCRIPTION
This will be tricky to test since it will be triggering a behavior (uploading the package) only when we try to merge a PR that has the label `release` (manually added) to a pull request.

I would like to go ahead and try a release after this gets merged and then fix posthumously the problems that might appear.

Basically, I added a custom label `release` that will be checked when a PR is being merged, if this condition holds, the procedure that we were doing manually to upload the pypi package should be executed.
In order to use the password I added a secret in the secrets-actions section of this Repo adding the token that you shared with me.

This will allow to use it in the github actions as shown here. 