### PR TITLE
Continue execution in case of wrong move input

### DIFF
--- a/hexgame/board.py
+++ b/hexgame/board.py
@@ -118,7 +118,7 @@ class Board:
         for nbr in nbrs:
             conn_comp.union((i, j), nbr)
 
-    def place_stone(self, i: int, j: int, color: Color):
+    def place_stone(self, i: int, j: int, color: Color) -> None:
         """
         place a stone at cell i,j on the board if this is empty
         and recomputes the connected components dictionary

--- a/hexgame/board.py
+++ b/hexgame/board.py
@@ -136,12 +136,12 @@ class Board:
                 self._number_of_moves_made += 1
             else:
                 raise ValueError(
-                    "Cannot place stone at cell {cell}-"
+                    "Cannot place stone at cell {cell}: "
                     "already occupied".format_map({"cell": (i, j)})
                 )
         else:
             raise ValueError(
-                "Cannot place stone at cell {cell}-"
+                "Cannot place stone at cell {cell}: "
                 "out of range".format_map({"cell": (i, j)})
             )
 

--- a/hexgame/board.py
+++ b/hexgame/board.py
@@ -118,6 +118,10 @@ class Board:
         for nbr in nbrs:
             conn_comp.union((i, j), nbr)
 
+    def _play(self, chosen_move) -> None:
+        i, j, color = chosen_move
+        self.place_stone(i, j, color)
+
     def place_stone(self, i: int, j: int, color: Color) -> None:
         """
         place a stone at cell i,j on the board if this is empty

--- a/hexgame/game.py
+++ b/hexgame/game.py
@@ -27,9 +27,30 @@ class Game:
         self.current_player: Player = self.player_1
 
     def _play(self) -> None:
-        # player  move
-        chosen_move: tuple[int, int, Color] = self.current_player.play(self.board)
-        self.board._play(chosen_move)
+        moved = False
+        trials_cap = 10
+        trials_num = 0
+        while not moved:
+            trials_num += 1
+            try:
+                # player  move
+                chosen_move: tuple[int, int, Color] = self.current_player.play(
+                    self.board
+                )
+                self.board._play(chosen_move)
+                moved = True
+            except ValueError as e:
+                print(
+                    f"Error in trying to perfom the choosen move:\n"
+                    f"x:{chosen_move[0]} y:{chosen_move[1]}"
+                    f" color:{chosen_move[2]}\n{e}\n"
+                )
+
+                if trials_num + 1 < trials_cap:
+                    print("Try to make a different move\n")
+                else:
+                    print("Maximum number of trials reached\n")
+                    raise ValueError(e)
 
         if self._has_player_won():
             self.status = self.GameStatus.Finished

--- a/hexgame/game.py
+++ b/hexgame/game.py
@@ -28,7 +28,8 @@ class Game:
 
     def _play(self) -> None:
         # player  move
-        self.current_player.play(self.board)
+        chosen_move: tuple[int, int, Color] = self.current_player.play(self.board)
+        self.board._play(chosen_move)
 
         if self._has_player_won():
             self.status = self.GameStatus.Finished

--- a/hexgame/player.py
+++ b/hexgame/player.py
@@ -21,37 +21,31 @@ class Player:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Player):
             return False
-
         return self.color == other.color
 
-    def _place_stone(self, board: Board, i, j) -> None:
-        board.place_stone(i, j, self.color)
-
     # here we define the playing logic
-    def play(self, board: Board) -> None:
+    def play(self, board: Board) -> tuple[int, int, Color]:
         """
         The main method that defines the playing behaviour
         based on player mode
         """
         match self.mode:
             case self.PlayerMode.AI:
-                self._random_policy(board)
+                return self._random_policy_move(board)
             case self.PlayerMode.Keyboard:
-                self._get_keyboard_move(board)
-            case _:
-                raise ValueError(f"Unknown mode {self.mode}")
+                return self._get_keyboard_move(board)
+        raise ValueError(f"Unknown mode {self.mode}")
 
-    def _random_policy(self, board: Board) -> None:
+    def _random_policy_move(self, board: Board) -> tuple[int, int, Color]:
         """
         Implements a random policy
         """
         available_actions = board.possible_moves
         if (available_actions) != []:
             next_move: tuple[int, int] = random.choice(available_actions)
-            i, j = next_move
-            self._place_stone(board, i, j)
+            return (next_move[0], next_move[1], self.color)
 
-    def _get_keyboard_move(self, board: Board) -> None:
+    def _get_keyboard_move(self, board: Board) -> tuple[int, int, Color]:
         """
         Waits for the keyboard input to get
         a move
@@ -76,7 +70,7 @@ class Player:
                             valid_coords = (
                                 board.has_cell((i, j)) and (i, j) in available_actions
                             )
-                            self._place_stone(board, i, j)
+                            return (i, j, self.color)
                         except ValueError as e:
                             print(e)
 

--- a/hexgame/player.py
+++ b/hexgame/player.py
@@ -24,11 +24,11 @@ class Player:
 
         return self.color == other.color
 
-    def _place_stone(self, board: Board, i, j):
+    def _place_stone(self, board: Board, i, j) -> None:
         board.place_stone(i, j, self.color)
 
     # here we define the playing logic
-    def play(self, board: Board):
+    def play(self, board: Board) -> None:
         """
         The main method that defines the playing behaviour
         based on player mode
@@ -41,7 +41,7 @@ class Player:
             case _:
                 raise ValueError(f"Unknown mode {self.mode}")
 
-    def _random_policy(self, board: Board):
+    def _random_policy(self, board: Board) -> None:
         """
         Implements a random policy
         """
@@ -51,7 +51,7 @@ class Player:
             i, j = next_move
             self._place_stone(board, i, j)
 
-    def _get_keyboard_move(self, board: Board):
+    def _get_keyboard_move(self, board: Board) -> None:
         """
         Waits for the keyboard input to get
         a move

--- a/hexgame/player.py
+++ b/hexgame/player.py
@@ -66,13 +66,10 @@ class Player:
                     inp = input()
                     if re.match("^[0-9]*$", inp) and len(inp) > 0:
                         j = int(inp)
-                        try:
-                            valid_coords = (
-                                board.has_cell((i, j)) and (i, j) in available_actions
-                            )
-                            return (i, j, self.color)
-                        except ValueError as e:
-                            print(e)
+                        valid_coords = (
+                            board.has_cell((i, j)) and (i, j) in available_actions
+                        )
+                        return (i, j, self.color)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is a draft because it is mixed with commits coming from #20 
It will be moved to proper PR when the other is merged and this becomes a standalone.

Therefore, have a look at the last commit only.

Here I am trying to change the behavior of the executable.
I am trying to make it so that it doesn't stop execution if an exception is raised when trying to make the selected move (because the move is not valid, namely out of range in the board or trying to occupy a square already taken).

Therefore I wrapped the `chose move` and  `make move` into a try-catch with a counter that allows to retry to make a move a finite number of times.

Also, I am removing the try catch in `Player::_get_keyboard_move` since `Board::has_cell` doesn't throw any exception.


This is the new behaviour (screenshot):
 
![Screenshot from 2023-05-12 13-14-16](https://github.com/dinies/HexGame/assets/14253035/9a10a5db-faab-4cac-af18-c565e6c8537f)


